### PR TITLE
Add missing include for monitoring checks

### DIFF
--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -2,6 +2,9 @@
 include:
   - java
   - python
+{% if salt['pillar.get']('monitoring:enabled', True) %}
+  - sensu.client
+{% endif %}
 
 
 /usr/src/packages/{{elasticsearch.source.file}}:


### PR DESCRIPTION
If monitoring is enabled (the default) we need this sls included so that
the check states can extend/notify it
