### PR TITLE
Limit fielddata cache size to 40% heap by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## CURRENT
+
+* Allow configuration of fielddata index cache
+
 ## Version 1.5.0
 
 * Fix up sensu monitor to not run on every node. See UPGRADING.md

--- a/elasticsearch/map.jinja
+++ b/elasticsearch/map.jinja
@@ -5,6 +5,8 @@
         'logs_path': '/var/log/elasticsearch',
         'node_name': salt['grains.get']('host'),
         'cluster_name': None,
+        'fielddata_cache_size': '40%',
+        'fielddata_cache_expire': None,
         'source': {
             'file': 'elasticsearch-1.3.1.deb',
             'path': 'http://static.dsd.io/packages',

--- a/elasticsearch/templates/elasticsearch.yml
+++ b/elasticsearch/templates/elasticsearch.yml
@@ -10,3 +10,9 @@ cluster.name: {{ elasticsearch.cluster_name }}
 {% if elasticsearch.node_name %}
 node.name: {{ elasticsearch.node_name }}
 {% endif %}
+{% if elasticsearch.fielddata_cache_size %}
+indices.fielddata.cache.size: {{ elasticsearch.fielddata_cache_size }}
+{% endif %}
+{% if elasticsearch.fielddata_cache_expire %}
+indices.fielddata.cache.expire: {{ elasticsearch.fielddata_cache_expire }}
+{% endif %}


### PR DESCRIPTION
As we're storing more data in ES, heap usage is seriously increasing.

LPA is at 2GB, PVB at 3GB now.

This is an attempt to reduce the amount of heap that we use to a
reasonably sensible level.

See http://www.elasticsearch.org/blog/using-elasticsearch-and-logstash-to-serve-billions-of-searchable-events-for-customers/ for more detail as to why.