### PR TITLE
Curator optimize; Make default options 'safe'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## CURRENT
+
+* Add optimize step to curator crons. Optimizing helps to reduce heap usage.
+
 ## Version 1.6.0
 
 * Allow configuration of fielddata index cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## CURRENT
 
 * Add optimize step to curator crons. Optimizing helps to reduce heap usage.
+* Adjust curator delete job to not run by default (DANGER!)
 
 ## Version 1.6.0
 

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@
 elasticsearch
 =======
 
-Formulas to set up and configure the elasticsearch server.
+Formulas to set up and configure the elasticsearch server, and associated
+housekeeping tasks via Curator.
 
 .. note::
 
@@ -55,6 +56,20 @@ Pillar variables
         MAX_LOCKED_MEMORY: unlimited
 
   (Do not treat these as recommend settings, they are just examples)
+
+- elasticsearch:curator
+
+  Configuration for the 'curator' housekeeping tool, specifically the 'delete'
+  and 'optimize' operations, enabled via cron.
+
+  Example (highlighting defaults)::
+
+    elasticsearch:
+      curator:
+        enabled: True
+        delete_options: None
+        optimize_options: '--older-than 3 --max_num_segments 1'
+
 
 warning
 =======

--- a/README.rst
+++ b/README.rst
@@ -62,12 +62,12 @@ Pillar variables
   Configuration for the 'curator' housekeeping tool, specifically the 'delete'
   and 'optimize' operations, enabled via cron.
 
-  Example (highlighting defaults)::
+  Example::
 
     elasticsearch:
       curator:
         enabled: True
-        delete_options: None
+        delete_options: '--older-than 90'
         optimize_options: '--older-than 3 --max_num_segments 1'
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,4 +1,16 @@
-## From 1.4 to CURRENT
+## From 1.6 to CURRENT
+
+The 'elasticsearch.curator.options' pillar has now been turned into two specific options:
+
+* 'elasticsearch.curator.delete_options'
+* 'elasticsearch.curator.optimize_options'
+
+By default, deletion will not occur, as this is not safe outside of our typical ELK stack usage.
+
+Optimize is set by default to compact the segments of each index over 3 days, as this is safe and
+saves a considerable amount of memory for ELK stacks.
+
+## From 1.4 to 1.5
 
 Sensu checks are not automatically deployed to the elasticsearch node.
 

--- a/elasticsearch/init.sls
+++ b/elasticsearch/init.sls
@@ -96,14 +96,41 @@ elasticsearch-curator:
     - require:
       - pkg: python-pip
 
-{% if elasticsearch.curator.enabled %}
+# Legacy, remove
 curator-cron:
-  cron.present:
-    - name: "/usr/local/bin/curator {{elasticsearch.curator.options}} 2> /var/log/elasticsearch/curator.err > /var/log/elasticsearch/curator.out"
+  cron.absent:
     - identifier: elasticsearch-curator-cron
+    - user: elasticsearch
+
+{% if elasticsearch.curator.enabled %}
+curator-delete-cron:
+{%   if elasticsearch.curator.delete_options %}
+  cron.present:
+    - name: "/usr/local/bin/curator delete {{elasticsearch.curator.delete_options}} 2>&1 | logger -t curator-delete"
+    - identifier: elasticsearch-curator-delete
     - user: elasticsearch
     - hour: '3'
     - minute: random
     - require:
       - pkg: elasticsearch
+{%   else %}
+  cron.absent:
+    - identifier: elasticsearch-curator-cron
+    - user: elasticsearch
+{%   endif %}
+curator-optimize-cron:
+{%   if elasticsearch.curator.optimize_options %}
+  cron.present:
+    - name: "/usr/local/bin/curator optimize {{elasticsearch.curator.optimize_options}} 2>&1 | logger -t curator-optimize"
+    - identifier: elasticsearch-curator-optimize
+    - user: elasticsearch
+    - hour: '4'
+    - minute: random
+    - require:
+      - pkg: elasticsearch
+{%   else %}
+  cron.absent:
+    - identifier: elasticsearch-curator-optimize
+    - user: elasticsearch
+{%   endif %}
 {% endif %}

--- a/elasticsearch/map.jinja
+++ b/elasticsearch/map.jinja
@@ -16,8 +16,9 @@
             'ES_HEAP_SIZE': '1g',
         },
         'curator': {
-            'enabled': False,
-            'options': 'delete --older-than 90',
+            'enabled': True,
+            'delete_options': None,
+            'optimize_options': '--older-than 3 --max_num_segments 1',
         }
     },
 }, merge=salt['pillar.get']('elasticsearch', {})) %}


### PR DESCRIPTION
Add a cron for 'curator optimize', as this -- in a typical ELK stack --
will save considerable amounts of heap space by reducing the segment count.

See https://gist.github.com/mikepea/511ebb8b723f69cea3a4 for details on this.

This elasticsearch-formula was also assuming it would be used in an
ELK stack (Logstash+Kibana) - deleting indexes after 90 days is not
necessarily a safe thing to do.

As such, adjust the curator options so that they are:

*) Optimise enabled -- pretty safe.
*) Delete is disabled

Also purge the old curator cron, which assumed that only delete would
be run. Curator requires multiple cron entries.